### PR TITLE
Pass onClose onto the bar-wrapper

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -5,12 +5,18 @@ import LinkButton from '@economist/component-link-button'
 export default function SubscribeMessage({
   renderSubscribeLink,
   renderCloseButton,
+  onClose,
   productImage = '/assets/product-image.png',
   href = 'https://subscriptions.economist.com'
 }) {
   const SubscribeLinkComponent = renderSubscribeLink || LinkButton;
   return (
-    <BarWrapper className="subscribe-message" classNamePrefix="subscribe-message" renderCloseButton={renderCloseButton}>
+    <BarWrapper
+      className="subscribe-message"
+      classNamePrefix="subscribe-message"
+      renderCloseButton={renderCloseButton}
+      onClose={onClose}
+    >
       <img className="subscribe-message__image" src={productImage} />
       <div className="subscribe-message__secondary-cta">
         Unlock the bigger picture every week with <em>The Economist</em>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-subscribe-message",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Subscribe message box with optional counter of read articles",
   "author": "The Economist (http://economist.com)",
   "license": "LicenseRef-LICENSE",


### PR DESCRIPTION
This allows us to listen to bar-wrapper's close event from the outside.